### PR TITLE
Update 04-starting-from-scratch.md

### DIFF
--- a/content/04-starting-from-scratch.md
+++ b/content/04-starting-from-scratch.md
@@ -131,7 +131,7 @@ export default {
 +	plugins: [
 +		resolve(),
 +		svelte({
-+			css: result => result.write('public/bundle/bundle.css')
++			css: result => result.write('public/build/bundle.css')
 +		})
 +	]
 };


### PR DESCRIPTION
Amend example of rollup.config write path for extracting CSS so it matches href attribute of <link> element in index.html example.